### PR TITLE
ci(docs): remove premature upload artifact step

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -46,15 +46,14 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: pip install .[docs]
       - run: mkdocs build
-      - uses: actions/upload-pages-artifact@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
There was a duplicate, premature upload step that was configured incorrectly. This removes it.

