### PR TITLE
ci: add license header validation check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 cmake_minimum_required(VERSION 3.18)
 project(ml_flashpoint_cpp LANGUAGES CXX)


### PR DESCRIPTION
Fixes #18

Confirmed it works by removing the license header for `CMakeLists.txt` here: https://github.com/google/ml-flashpoint/pull/27/checks?sha=7bb36ee0cf3c9d14ff2a74e532f6e39afacf0350