### PR TITLE
ci: re-enable clang-format check in build workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -107,9 +107,9 @@ jobs:
       run: |
         # Install and run C++ linter
         echo -e "\n##### Installing and running clang-format linter #####"
-        sudo apt-get update && sudo apt-get install -y clang-format
-        clang-format --version
-        find src -name '*.cpp' -o -name '*.h' | xargs clang-format --dry-run --Werror
+        sudo apt-get update && sudo apt-get install -y clang-format-18
+        clang-format-18 --version
+        find src -name '*.cpp' -o -name '*.h' | xargs clang-format-18 --dry-run --Werror
 
   lint-license:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -100,16 +100,16 @@ You can prompt your coding tool to "create a comprehensive test plan for X, cove
 *   **C++ Format:** To apply automated fixes, run:
 
     ```bash
-    # install clang-format
-    sudo apt-get update && sudo apt-get install -y clang-format
+    # install clang-format-18
+    sudo apt-get update && sudo apt-get install -y clang-format-18
 
     # format all C++ files
-    find src -name '*.cpp' -o -name '*.h' | xargs clang-format -i
+    find src -name '*.cpp' -o -name '*.h' | xargs clang-format-18 -i
     ```
 
 *   **C++ Lint:** Check for style violations, run:
     ```bash
-    find src -name '*.cpp' -o -name '*.h' | xargs clang-format --dry-run --Werror
+    find src -name '*.cpp' -o -name '*.h' | xargs clang-format-18 --dry-run --Werror
     ```
 
 *   **Test:** To run all tests (Python and C++), run:


### PR DESCRIPTION
Fix clang-format in build #2

