### PR TITLE
ci: make published package version dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ build-backend = "scikit_build_core.build"
 [tool.scikit-build]
 
 # Tells scikit-build-core to use setuptools-scm to retrieve the version from git.
-metadata.version-provider = "scikit_build_core.metadata.setuptools_scm"
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 # Specifies the minimum version of CMake that must be present on the system.
 cmake.version = ">=3.18"


### PR DESCRIPTION
Auto-set project's version attribute based on git tag, so pypi published package has the right version.