### PR TITLE
feat(replication): support single-node execution by disabling replica…

### DIFF
--- a/src/ml_flashpoint/replication/replication_manager.py
+++ b/src/ml_flashpoint/replication/replication_manager.py
@@ -123,7 +123,7 @@ class PairwiseReplicationStrategy(ReplicationStrategy):
 
     @override
     def get_destination_addresses(self, global_rank: int) -> List[str]:
-        if getattr(self, "_disable_replication", False):
+        if self._disable_replication:
             return []
 
         if not 0 <= global_rank < self._world_size:

--- a/src/ml_flashpoint/replication/replication_manager.py
+++ b/src/ml_flashpoint/replication/replication_manager.py
@@ -448,9 +448,6 @@ class ReplicationManager:
         Returns:
             `True` if the bulk retrieval was successful, `False` otherwise.
         """
-        if utils.get_num_of_nodes() == 1:
-            _LOGGER.info("Single node detected; skipping bulk retrieve.")
-            return False
 
         if self._retry_config is None:
             _LOGGER.error("ReplicationManager is not initialized. Cannot retrieve.")

--- a/src/ml_flashpoint/replication/replication_manager.py
+++ b/src/ml_flashpoint/replication/replication_manager.py
@@ -108,8 +108,12 @@ class PairwiseReplicationStrategy(ReplicationStrategy):
             )
 
         self._num_nodes = utils.get_num_of_nodes()
-        if self._num_nodes % 2 != 0:
-            raise ValueError(f"The total number of nodes ({self._num_nodes}) must be even.")
+        # Allow 1-node execution by bypassing the even-number node check.
+        # Pairwise replication requires an even number of nodes, but we allow exactly 1 node
+        # to run without any replication.
+        if self._num_nodes > 1 and self._num_nodes % 2 != 0:
+            raise ValueError(f"The total number of nodes ({self._num_nodes}) must be even for pairwise replication.")
+        self._disable_replication = self._num_nodes == 1
 
         if self._num_nodes != self._world_size // self._processes_per_node:
             raise ValueError(
@@ -119,6 +123,9 @@ class PairwiseReplicationStrategy(ReplicationStrategy):
 
     @override
     def get_destination_addresses(self, global_rank: int) -> List[str]:
+        if getattr(self, "_disable_replication", False):
+            return []
+
         if not 0 <= global_rank < self._world_size:
             raise ValueError(f"global_rank {global_rank} is out of valid range [0, {self._world_size - 1}].")
 
@@ -441,6 +448,10 @@ class ReplicationManager:
         Returns:
             `True` if the bulk retrieval was successful, `False` otherwise.
         """
+        if utils.get_num_of_nodes() == 1:
+            _LOGGER.info("Single node detected; skipping bulk retrieve.")
+            return False
+
         if self._retry_config is None:
             _LOGGER.error("ReplicationManager is not initialized. Cannot retrieve.")
             return False

--- a/tests/core/test_checkpoint_loader.py
+++ b/tests/core/test_checkpoint_loader.py
@@ -998,11 +998,10 @@ class TestGetLatestCompleteCheckpoint:
         assert result == ckpt_id
         mock_retrieve.assert_not_called()
 
-
     def test_single_node_shared_storage_no_retrieval_needed(self, loader, mocker):
         """
         Tests that in a 1-node setup (e.g., fallback to NFS or local shared storage),
-        the loader correctly computes an empty retrieval plan. It does not attempt to 
+        the loader correctly computes an empty retrieval plan. It does not attempt to
         fetch from non-existent peer nodes, allowing the process to execute correctly
         without throwing an error.
         """
@@ -1010,7 +1009,7 @@ class TestGetLatestCompleteCheckpoint:
         self.mock_dist_get_rank.return_value = 0
         self.mock_get_num_nodes.return_value = 1
         self.mock_dist_get_world_size.return_value = 2
-        
+
         base_container = CheckpointContainerId("/tmp/checkpoints")
         ckpt_id = CheckpointContainerId.create_child(base_container, "step-100_ckpt")
         mocker.patch.object(loader, "get_candidate_checkpoints", return_value=[ckpt_id])
@@ -1024,7 +1023,7 @@ class TestGetLatestCompleteCheckpoint:
         mocker.patch.object(loader, "read_metadata", return_value=mock_metadata)
 
         # Mock available objects: Rank 0 sees src0, Rank 1 sees src1.
-        # However, since they are on the same node (num_nodes=1), the underlying system 
+        # However, since they are on the same node (num_nodes=1), the underlying system
         # can see all files via NFS/local disk.
         mocker.patch.object(
             loader,
@@ -1048,23 +1047,21 @@ class TestGetLatestCompleteCheckpoint:
         # When: Execute the core logic to get the latest checkpoint
         result = loader.get_latest_complete_checkpoint(base_container)
 
-        # Then: 
+        # Then:
         # Verify that the method executes correctly instead of crashing with an error.
         assert result == ckpt_id
-        
+
         # Verify that the generated retrieval plan is empty (no network fetch to non-existent peers).
         args, _ = self.mock_dist_broadcast_object_list.call_args
         plan_container = args[0]
         plan = plan_container[0]
-        
+
         # Assert that the network retries wval plan for all ranks is empty (perfect fallback to NFS/Local read).
         assert not plan.get(0)
         assert not plan.get(1)
-        
+
         # Verify that the subsequent flow skips retrieval entirely since it's locally available.
         mock_retrieve.assert_not_called()
-
-
 
     def test_non_rank0_success(self, loader, mocker):
         """Tests successful retrieval flow on non-Rank 0."""

--- a/tests/core/test_checkpoint_loader.py
+++ b/tests/core/test_checkpoint_loader.py
@@ -998,6 +998,71 @@ class TestGetLatestCompleteCheckpoint:
         assert result == ckpt_id
         mock_retrieve.assert_not_called()
 
+    def test_single_node_shared_storage_no_retrieval_needed(self, loader, mocker):
+        """
+        Tests that in a 1-node setup (e.g., fallback to NFS or local shared storage),
+        the loader correctly computes an empty retrieval plan. It does not attempt to
+        fetch from non-existent peer nodes, allowing the process to execute correctly
+        without throwing an error.
+        """
+        # Given: Simulate a single-node environment (1 node, 2 ranks)
+        self.mock_dist_get_rank.return_value = 0
+        self.mock_get_num_nodes.return_value = 1
+        self.mock_dist_get_world_size.return_value = 2
+
+        base_container = CheckpointContainerId("/tmp/checkpoints")
+        ckpt_id = CheckpointContainerId.create_child(base_container, "step-100_ckpt")
+        mocker.patch.object(loader, "get_candidate_checkpoints", return_value=[ckpt_id])
+
+        # Mock metadata indicating what needs to be loaded
+        mock_metadata = mocker.MagicMock()
+        mock_metadata.storage_data = {
+            0: _StorageInfo(relative_path="/src0/obj", offset=0, length=100),
+            1: _StorageInfo(relative_path="/src1/obj", offset=0, length=100),
+        }
+        mocker.patch.object(loader, "read_metadata", return_value=mock_metadata)
+
+        # Mock available objects: Rank 0 sees src0, Rank 1 sees src1.
+        # However, since they are on the same node (num_nodes=1), the underlying system
+        # can see all files via NFS/local disk.
+        mocker.patch.object(
+            loader,
+            "get_checkpoint_objects_by_rank",
+            return_value={
+                0: [
+                    CheckpointObjectId("/tmp/checkpoints/step-100_ckpt/src0/obj"),
+                    CheckpointObjectId("/tmp/checkpoints/step-100_ckpt/.metadata"),
+                    CheckpointObjectId("/tmp/checkpoints/step-100_ckpt/common.pt"),
+                ],
+                1: [
+                    CheckpointObjectId("/tmp/checkpoints/step-100_ckpt/src1/obj"),
+                    CheckpointObjectId("/tmp/checkpoints/step-100_ckpt/.metadata"),
+                    CheckpointObjectId("/tmp/checkpoints/step-100_ckpt/common.pt"),
+                ],
+            },
+        )
+
+        mock_retrieve = mocker.patch.object(loader, "retrieve_checkpoint", return_value=True)
+
+        # When: Execute the core logic to get the latest checkpoint
+        result = loader.get_latest_complete_checkpoint(base_container)
+
+        # Then:
+        # 1. Verify that the method executes correctly instead of crashing with an error.
+        assert result == ckpt_id
+
+        # 2. Verify that the generated retrieval plan is empty (no network fetch to non-existent peers).
+        args, _ = self.mock_dist_broadcast_object_list.call_args
+        plan_container = args[0]
+        plan = plan_container[0]
+
+        # Assert that the network retries wval plan for all ranks is empty (perfect fallback to NFS/Local read).
+        assert not plan.get(0)
+        assert not plan.get(1)
+
+        # 3. Verify that the subsequent flow skips retrieval entirely since it's locally available.
+        mock_retrieve.assert_not_called()
+
     def test_non_rank0_success(self, loader, mocker):
         """Tests successful retrieval flow on non-Rank 0."""
         # Given

--- a/tests/core/test_checkpoint_loader.py
+++ b/tests/core/test_checkpoint_loader.py
@@ -998,10 +998,11 @@ class TestGetLatestCompleteCheckpoint:
         assert result == ckpt_id
         mock_retrieve.assert_not_called()
 
+
     def test_single_node_shared_storage_no_retrieval_needed(self, loader, mocker):
         """
         Tests that in a 1-node setup (e.g., fallback to NFS or local shared storage),
-        the loader correctly computes an empty retrieval plan. It does not attempt to
+        the loader correctly computes an empty retrieval plan. It does not attempt to 
         fetch from non-existent peer nodes, allowing the process to execute correctly
         without throwing an error.
         """
@@ -1009,7 +1010,7 @@ class TestGetLatestCompleteCheckpoint:
         self.mock_dist_get_rank.return_value = 0
         self.mock_get_num_nodes.return_value = 1
         self.mock_dist_get_world_size.return_value = 2
-
+        
         base_container = CheckpointContainerId("/tmp/checkpoints")
         ckpt_id = CheckpointContainerId.create_child(base_container, "step-100_ckpt")
         mocker.patch.object(loader, "get_candidate_checkpoints", return_value=[ckpt_id])
@@ -1023,7 +1024,7 @@ class TestGetLatestCompleteCheckpoint:
         mocker.patch.object(loader, "read_metadata", return_value=mock_metadata)
 
         # Mock available objects: Rank 0 sees src0, Rank 1 sees src1.
-        # However, since they are on the same node (num_nodes=1), the underlying system
+        # However, since they are on the same node (num_nodes=1), the underlying system 
         # can see all files via NFS/local disk.
         mocker.patch.object(
             loader,
@@ -1047,21 +1048,23 @@ class TestGetLatestCompleteCheckpoint:
         # When: Execute the core logic to get the latest checkpoint
         result = loader.get_latest_complete_checkpoint(base_container)
 
-        # Then:
-        # 1. Verify that the method executes correctly instead of crashing with an error.
+        # Then: 
+        # Verify that the method executes correctly instead of crashing with an error.
         assert result == ckpt_id
-
-        # 2. Verify that the generated retrieval plan is empty (no network fetch to non-existent peers).
+        
+        # Verify that the generated retrieval plan is empty (no network fetch to non-existent peers).
         args, _ = self.mock_dist_broadcast_object_list.call_args
         plan_container = args[0]
         plan = plan_container[0]
-
+        
         # Assert that the network retries wval plan for all ranks is empty (perfect fallback to NFS/Local read).
         assert not plan.get(0)
         assert not plan.get(1)
-
-        # 3. Verify that the subsequent flow skips retrieval entirely since it's locally available.
+        
+        # Verify that the subsequent flow skips retrieval entirely since it's locally available.
         mock_retrieve.assert_not_called()
+
+
 
     def test_non_rank0_success(self, loader, mocker):
         """Tests successful retrieval flow on non-Rank 0."""

--- a/tests/replication/test_replication_manager.py
+++ b/tests/replication/test_replication_manager.py
@@ -16,12 +16,17 @@ from concurrent.futures import Future
 
 import pytest
 
-from ml_flashpoint.replication.replication_manager import ReplicationManager, ReplicationRetryConfig
+from ml_flashpoint.replication.replication_manager import (
+    PairwiseReplicationStrategy,
+    ReplicationManager,
+    ReplicationRetryConfig,
+)
 
 
 @pytest.fixture
 def replication_manager(mocker):
     """Provides a ReplicationManager instance with mocked dependencies."""
+    mocker.patch("ml_flashpoint.core.utils.get_num_of_nodes", return_value=2)
     manager = ReplicationManager()
     manager._transfer_service = mocker.MagicMock()
     manager._repl_strategy = mocker.MagicMock()
@@ -338,3 +343,49 @@ def test_sync_bulk_retrieve_invalid_rank(replication_manager):
 
     # Then
     assert result is False
+
+
+def test_pairwise_strategy_single_node_initialization(mocker):
+    """Tests that PairwiseReplicationStrategy successfully initializes for a single node without raising an error."""
+    # Given
+    mocker.patch("ml_flashpoint.core.utils.get_num_of_nodes", return_value=1)
+    # Simulate a single node with 2 processes (GPUs)
+    addresses = ["127.0.0.1:8000", "127.0.0.1:8001"]
+
+    # When
+    strategy = PairwiseReplicationStrategy(replication_service_addresses=addresses, processes_per_node=2)
+
+    # Then
+    assert getattr(strategy, "_disable_replication", False) is True
+
+
+def test_pairwise_strategy_single_node_get_destination(mocker):
+    """Tests that get_destination_addresses returns an empty list when running on a single node."""
+    # Given
+    mocker.patch("ml_flashpoint.core.utils.get_num_of_nodes", return_value=1)
+    addresses = ["127.0.0.1:8000"]
+    strategy = PairwiseReplicationStrategy(replication_service_addresses=addresses, processes_per_node=1)
+
+    # When
+    destinations = strategy.get_destination_addresses(global_rank=0)
+
+    # Then
+    assert destinations == []
+
+
+def test_sync_bulk_retrieve_single_node_skips(replication_manager, mocker):
+    """Tests that sync_bulk_retrieve immediately returns False in a single-node environment."""
+    # Given
+    mocker.patch("ml_flashpoint.core.utils.get_num_of_nodes", return_value=1)
+    mocker.patch.object(replication_manager, "_async_retrieve")
+
+    obj_ids = ["obj1", "obj2"]
+    container_ids = []
+
+    # When
+    result = replication_manager.sync_bulk_retrieve(0, obj_ids, container_ids)
+
+    # Then
+    assert result is False
+    # Ensure that no network retrieval attempts were made
+    replication_manager._async_retrieve.assert_not_called()

--- a/tests/replication/test_replication_manager.py
+++ b/tests/replication/test_replication_manager.py
@@ -26,7 +26,6 @@ from ml_flashpoint.replication.replication_manager import (
 @pytest.fixture
 def replication_manager(mocker):
     """Provides a ReplicationManager instance with mocked dependencies."""
-    mocker.patch("ml_flashpoint.core.utils.get_num_of_nodes", return_value=2)
     manager = ReplicationManager()
     manager._transfer_service = mocker.MagicMock()
     manager._repl_strategy = mocker.MagicMock()
@@ -373,19 +372,29 @@ def test_pairwise_strategy_single_node_get_destination(mocker):
     assert destinations == []
 
 
-def test_sync_bulk_retrieve_single_node_skips(replication_manager, mocker):
-    """Tests that sync_bulk_retrieve immediately returns False in a single-node environment."""
+def test_async_replicate_single_node_skips(replication_manager, mocker):
+    """Tests that async_replicate does nothing and returns empty futures in a single-node environment."""
     # Given
     mocker.patch("ml_flashpoint.core.utils.get_num_of_nodes", return_value=1)
-    mocker.patch.object(replication_manager, "_async_retrieve")
+    addresses = ["127.0.0.1:8000"]
+    # Initialize the strategy with 1 node
+    strategy = PairwiseReplicationStrategy(replication_service_addresses=addresses, processes_per_node=1)
+    replication_manager._repl_strategy = strategy
 
-    obj_ids = ["obj1", "obj2"]
-    container_ids = []
+    mocker.patch("torch.distributed.get_rank", return_value=0)
+
+    buffer_object = mocker.MagicMock()
+    buffer_object.get_id.return_value = "test_single_node_obj"
+    buffer_io = mocker.MagicMock(buffer_obj=buffer_object)
 
     # When
-    result = replication_manager.sync_bulk_retrieve(0, obj_ids, container_ids)
+    result_futures = replication_manager.async_replicate(buffer_io)
 
     # Then
-    assert result is False
-    # Ensure that no network retrieval attempts were made
-    replication_manager._async_retrieve.assert_not_called()
+    assert result_futures == []
+    # Ensure transfer service is NOT called
+    replication_manager._transfer_service.async_put.assert_not_called()
+    # Ensure the buffer is closed properly
+    replication_manager._checkpoint_object_manager.close_buffer.assert_called_once_with(
+        buffer_io, skip_close_if_symlink=True
+    )


### PR DESCRIPTION
Currently, ML Flashpoint requires an even number of nodes due to the pairwise replication strategy. This prevents the library from running in single-node environments, which is often required in some testing scenarios. 

This commit adds support for single-node execution by safely bypassing replication logic while keeping the core save/load functionality intact.
