### PR TITLE
perf(adapter/nemo): set use_fully_parallel_wrapper default to True

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -93,8 +93,8 @@ auto_resume = wrap_trainer_and_auto_resume_with_mlflashpoint(
     # write_thread_count=1, # Optional, defaults to 1
     # initial_write_buffer_size_bytes=DESIRED_NUM_BYTES, # Optional, defaults to 16 GB
     # use_optimized_save=True, # Optional, defaults to True. Uses the optimized save method to reduce write time.
-    # use_cached_ckpt_structure=True, # Optional, defaults to False. Caches the checkpoint structure after identifying 2 consecutive save plan structures that are equal.
-    # use_fully_parallel_wrapper=False, # Optional, defaults to True. Uses the fully parallel wrapper for save and load.
+    # use_cached_ckpt_structure=False, # Optional, defaults to False. Caches the checkpoint structure after identifying 2 consecutive save plan structures that are equal.
+    # use_fully_parallel_wrapper=True, # Optional, defaults to True. Uses the fully parallel wrapper for save and load.
 )
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -94,6 +94,7 @@ auto_resume = wrap_trainer_and_auto_resume_with_mlflashpoint(
     # initial_write_buffer_size_bytes=DESIRED_NUM_BYTES, # Optional, defaults to 16 GB
     # use_optimized_save=True, # Optional, defaults to True. Uses the optimized save method to reduce write time.
     # use_cached_ckpt_structure=True, # Optional, defaults to False. Caches the checkpoint structure after identifying 2 consecutive save plan structures that are equal.
+    # use_fully_parallel_wrapper=False, # Optional, defaults to True. Uses the fully parallel wrapper for save and load.
 )
 ```
 

--- a/src/ml_flashpoint/adapter/nemo/wrapper_util.py
+++ b/src/ml_flashpoint/adapter/nemo/wrapper_util.py
@@ -57,7 +57,7 @@ def wrap_trainer_and_auto_resume_with_mlflashpoint(
     initial_write_buffer_size_bytes: Optional[int] = DEFAULT_INITIAL_BUFFER_SIZE_BYTES,
     use_optimized_save: bool = True,
     use_cached_ckpt_structure: bool = False,
-    use_fully_parallel_wrapper: bool = False,
+    use_fully_parallel_wrapper: bool = True,
 ) -> MLFlashpointAutoResume:
     """Wraps the trainer and creates an MLFlashpointAutoResume instance wrapping `default_auto_resume`.
 
@@ -79,7 +79,7 @@ def wrap_trainer_and_auto_resume_with_mlflashpoint(
             Defaults to False.
         use_fully_parallel_wrapper: Whether to use the fully parallel wrapper for save and load.
             This will evenly distribute checkpoint data across all ranks.
-            Defaults to False.
+            Defaults to True.
 
     Returns:
         An MLFlashpointAutoResume instance configured for ML Flashpoint, wrapping `default_auto_resume`.
@@ -146,7 +146,7 @@ def wrap_trainer_checkpoint_io_with_mlflashpoint(
     initial_write_buffer_size_bytes: Optional[int] = DEFAULT_INITIAL_BUFFER_SIZE_BYTES,
     use_optimized_save: bool = True,
     use_cached_ckpt_structure: bool = False,
-    use_fully_parallel_wrapper: bool = False,
+    use_fully_parallel_wrapper: bool = True,
 ):
     """Wraps the trainer's checkpoint I/O with ML Flashpoint capabilities.
 
@@ -178,7 +178,7 @@ def wrap_trainer_checkpoint_io_with_mlflashpoint(
             Defaults to False.
         use_fully_parallel_wrapper: Whether to use the fully parallel wrapper for save and load.
             This will evenly distribute checkpoint data across all ranks.
-            Defaults to False.
+            Defaults to True.
 
     Returns:
         None. The trainer's checkpoint_io is modified in-place.

--- a/tests/adapter/nemo/test_wrapper_util.py
+++ b/tests/adapter/nemo/test_wrapper_util.py
@@ -132,7 +132,7 @@ class TestWrapTrainerAndAutoResumeWithMLFlashpoint:
             initial_write_buffer_size_bytes=DEFAULT_INITIAL_BUFFER_SIZE_BYTES,
             use_optimized_save=True,
             use_cached_ckpt_structure=False,
-            use_fully_parallel_wrapper=False,
+            use_fully_parallel_wrapper=True,
         )
 
         # 3. Result is correct type and has correct attributes
@@ -376,7 +376,7 @@ class TestWrapTrainerAndAutoResumeWithMLFlashpoint:
         assert kwargs["use_fully_parallel_wrapper"] is use_fully_parallel_wrapper
 
     def test_use_fully_parallel_wrapper_default_value(self, mocker):
-        """Tests that use_fully_parallel_wrapper defaults to False."""
+        """Tests that use_fully_parallel_wrapper defaults to True."""
         # Given
         mocker.patch("ml_flashpoint.adapter.nemo.wrapper_util.ReplicationManager")
         mock_wrap_trainer = mocker.patch(
@@ -398,7 +398,7 @@ class TestWrapTrainerAndAutoResumeWithMLFlashpoint:
         # Then
         mock_wrap_trainer.assert_called_once()
         _, kwargs = mock_wrap_trainer.call_args
-        assert kwargs["use_fully_parallel_wrapper"] is False
+        assert kwargs["use_fully_parallel_wrapper"] is True
 
 
 class TestWrapTrainerCheckpointIOWithMLFlashpoint:
@@ -639,7 +639,7 @@ class TestWrapTrainerCheckpointIOWithMLFlashpoint:
             FullyParallelLoadStrategyWrapper,
         )
 
-    def test_fully_parallel_wrapper_disabled_by_default(self, mocker, mock_ckpt_obj_manager, mock_replication_manager):
+    def test_fully_parallel_wrapper_disabled_explicitly(self, mocker, mock_ckpt_obj_manager, mock_replication_manager):
         """Tests that FullyParallel wrappers are NOT applied when flag=False."""
 
         # Given
@@ -658,7 +658,7 @@ class TestWrapTrainerCheckpointIOWithMLFlashpoint:
             mock_replication_manager,
             async_save=True,
             checkpoint_loader=mocker.MagicMock(spec=DefaultMLFlashpointCheckpointLoader),
-            use_fully_parallel_wrapper=False,  # default behavior
+            use_fully_parallel_wrapper=False,
         )
 
         # Then
@@ -1150,6 +1150,7 @@ class TestWrapTrainerCheckpointIOWithMLFlashpoint:
             mock_replication_manager,
             async_save=True,
             checkpoint_loader=mock_loader,
+            use_fully_parallel_wrapper=False,
         )
 
         # Then


### PR DESCRIPTION
This change optimizes write throughput and significantly reduces recovery times by evenly distributing checkpoint data across all ranks.

- Improved write throughput & load balancing between all nodes
- Faster recovery when need to retrieve missing checkpoints in some nodes
- No performance regression for end to end training time