### PR TITLE
fix(adapter/nemo): safely call maybe_finalize_save_checkpoint in on_train_end

### DIFF
--- a/src/ml_flashpoint/adapter/nemo/checkpoint_callback.py
+++ b/src/ml_flashpoint/adapter/nemo/checkpoint_callback.py
@@ -178,7 +178,9 @@ class MLFlashpointCheckpointCallback(pl_callbacks.Callback):
         _LOGGER.info("Training ended. Synchronizing and finalizing checkpoints...")
 
         # 1. Wait for async checkpoint saves to finish locally
-        trainer.strategy.checkpoint_io.maybe_finalize_save_checkpoint(blocking=True)
+        # Only finalize if the CheckpointIO implementation supports it (e.g., async mode).
+        if hasattr(trainer.strategy.checkpoint_io, "maybe_finalize_save_checkpoint"):
+            trainer.strategy.checkpoint_io.maybe_finalize_save_checkpoint(blocking=True)
 
         # 2. Synchronize all ranks to ensure background writes are done everywhere before deletion
         trainer.strategy.barrier("mlf_cleanup_barrier")

--- a/src/ml_flashpoint/adapter/nemo/checkpoint_callback.py
+++ b/src/ml_flashpoint/adapter/nemo/checkpoint_callback.py
@@ -18,6 +18,7 @@ from typing import Any, Optional, Union
 import lightning.pytorch as pl
 from lightning.pytorch import callbacks as pl_callbacks
 from lightning.pytorch.utilities import types as pl_util_types
+from nemo.utils.callbacks.dist_ckpt_io import AsyncFinalizableCheckpointIO
 from typing_extensions import override
 
 from ml_flashpoint.core import mlf_logging
@@ -179,7 +180,7 @@ class MLFlashpointCheckpointCallback(pl_callbacks.Callback):
 
         # 1. Wait for async checkpoint saves to finish locally
         # Only finalize if the CheckpointIO implementation supports it (e.g., async mode).
-        if hasattr(trainer.strategy.checkpoint_io, "maybe_finalize_save_checkpoint"):
+        if isinstance(trainer.strategy.checkpoint_io, AsyncFinalizableCheckpointIO):
             trainer.strategy.checkpoint_io.maybe_finalize_save_checkpoint(blocking=True)
 
         # 2. Synchronize all ranks to ensure background writes are done everywhere before deletion

--- a/tests/adapter/nemo/test_checkpoint_callback.py
+++ b/tests/adapter/nemo/test_checkpoint_callback.py
@@ -551,3 +551,33 @@ def test_on_train_end_skips_cleanup_when_flag_is_true(mocker, tmp_path):
 
     assert base_container_path.exists(), "Base container directory should NOT have been deleted"
     assert dummy_file.exists(), "Dummy file should NOT have been deleted"
+
+
+def test_on_train_end_with_sync_checkpoint_io(mocker):
+    """
+    Tests that on_train_end executes successfully during synchronous saving.
+    """
+    mock_trainer = mocker.MagicMock()
+    mock_strategy = mocker.MagicMock()
+    mock_checkpoint_io = mocker.MagicMock()
+
+    # Remove the async-specific method to simulate a synchronous CheckpointIO instance.
+    del mock_checkpoint_io.maybe_finalize_save_checkpoint
+
+    mock_strategy.checkpoint_io = mock_checkpoint_io
+    mock_trainer.strategy = mock_strategy
+    mock_trainer.local_rank = 0
+
+    callback = MLFlashpointCheckpointCallback(
+        checkpoint_base_container="/tmp/fake_base",
+        every_n_steps=10,
+    )
+
+    # Execute on_train_end; it should gracefully skip finalization without errors.
+    try:
+        callback.on_train_end(trainer=mock_trainer, pl_module=mocker.MagicMock())
+    except AttributeError as e:
+        pytest.fail(f"on_train_end failed to handle synchronous CheckpointIO: {e}")
+
+    # Verify that the subsequent cleanup steps (e.g., barrier) are still reached.
+    mock_trainer.strategy.barrier.assert_called_once_with("mlf_cleanup_barrier")

--- a/tests/adapter/nemo/test_checkpoint_callback.py
+++ b/tests/adapter/nemo/test_checkpoint_callback.py
@@ -22,7 +22,7 @@ from ml_flashpoint.adapter.nemo.checkpoint_callback import (
     ML_FLASHPOINT_TYPE,
     MLFlashpointCheckpointCallback,
 )
-from ml_flashpoint.adapter.nemo.checkpoint_io import MLFlashpointCheckpointIO
+from ml_flashpoint.adapter.nemo.checkpoint_io import MLFlashpointAsyncFinalizableCheckpointIO, MLFlashpointCheckpointIO
 from ml_flashpoint.checkpoint_object_manager.checkpoint_object_manager import CheckpointObjectManager
 from ml_flashpoint.core.checkpoint_id_types import CheckpointContainerId
 from ml_flashpoint.core.mlf_logging import _TRAINING_STEP
@@ -371,9 +371,10 @@ def test_on_train_end_cleans_up_on_rank_zero(mocker, tmp_path):
         load_strategy=mocker.MagicMock(),
         trainer=trainer,
     )
-    checkpoint_io.maybe_finalize_save_checkpoint = mocker.MagicMock()
     mocker.spy(checkpoint_io, "remove_checkpoint")
-    trainer.strategy.checkpoint_io = checkpoint_io
+    wrapped_io = MLFlashpointAsyncFinalizableCheckpointIO(checkpoint_io)
+    mocker.spy(wrapped_io, "maybe_finalize_save_checkpoint")
+    trainer.strategy.checkpoint_io = wrapped_io
 
     pl_module = mocker.MagicMock(spec=pl.LightningModule)
 
@@ -391,7 +392,7 @@ def test_on_train_end_cleans_up_on_rank_zero(mocker, tmp_path):
     callback.on_train_end(trainer, pl_module)
 
     # Then
-    checkpoint_io.maybe_finalize_save_checkpoint.assert_called_once_with(blocking=True)
+    wrapped_io.maybe_finalize_save_checkpoint.assert_called_once_with(blocking=True)
     trainer.strategy.barrier.assert_called_once_with("mlf_cleanup_barrier")
     callback.replication_manager.shutdown.assert_called_once()
     checkpoint_io.remove_checkpoint.assert_called_once_with(base_container.data)
@@ -404,8 +405,21 @@ def test_on_train_end_skips_cleanup_on_non_zero_rank(mocker, tmp_path):
     # Given
     trainer = mocker.MagicMock(spec=pl.Trainer)
     trainer.local_rank = 1
-    checkpoint_io = mocker.MagicMock()
-    trainer.strategy.checkpoint_io = checkpoint_io
+    chkpt_obj_manager = CheckpointObjectManager()
+
+    checkpoint_io = MLFlashpointCheckpointIO(
+        flashpoint_base_path=str(tmp_path / "ckpt_base"),
+        alt_checkpoint_io=mocker.MagicMock(),
+        chkpt_obj_manager=chkpt_obj_manager,
+        save_strategy=mocker.MagicMock(),
+        load_strategy=mocker.MagicMock(),
+        trainer=trainer,
+    )
+    mocker.spy(checkpoint_io, "remove_checkpoint")
+
+    wrapped_io = MLFlashpointAsyncFinalizableCheckpointIO(checkpoint_io)
+    mocker.spy(wrapped_io, "maybe_finalize_save_checkpoint")
+    trainer.strategy.checkpoint_io = wrapped_io
 
     pl_module = mocker.MagicMock(spec=pl.LightningModule)
 
@@ -423,13 +437,12 @@ def test_on_train_end_skips_cleanup_on_non_zero_rank(mocker, tmp_path):
     callback.on_train_end(trainer, pl_module)
 
     # Then
-    checkpoint_io.maybe_finalize_save_checkpoint.assert_called_once_with(blocking=True)
+    wrapped_io.maybe_finalize_save_checkpoint.assert_called_once_with(blocking=True)
+    trainer.strategy.barrier.assert_called_once_with("mlf_cleanup_barrier")
     callback.replication_manager.shutdown.assert_called_once()
-    checkpoint_io.remove_checkpoint.assert_not_called()
 
-    # Verify file retention
-    assert base_container_path.exists(), "Base container directory should NOT have been deleted"
-    assert dummy_file.exists(), "Dummy file should NOT have been deleted"
+    checkpoint_io.remove_checkpoint.assert_not_called()
+    assert base_container_path.exists()
 
 
 def test_on_train_end_no_replication_manager_skips_shutdown(mocker):
@@ -469,9 +482,11 @@ def test_on_train_end_is_idempotent(mocker, tmp_path):
         load_strategy=mocker.MagicMock(),
         trainer=trainer,
     )
-    checkpoint_io.maybe_finalize_save_checkpoint = mocker.MagicMock()
     mocker.spy(checkpoint_io, "remove_checkpoint")
-    trainer.strategy.checkpoint_io = checkpoint_io
+
+    wrapped_io = MLFlashpointAsyncFinalizableCheckpointIO(checkpoint_io)
+    mocker.spy(wrapped_io, "maybe_finalize_save_checkpoint")
+    trainer.strategy.checkpoint_io = wrapped_io
 
     pl_module = mocker.MagicMock(spec=pl.LightningModule)
 
@@ -492,7 +507,7 @@ def test_on_train_end_is_idempotent(mocker, tmp_path):
     # Then
     assert callback.replication_manager.shutdown.call_count == 2
     assert checkpoint_io.remove_checkpoint.call_count == 2
-    assert checkpoint_io.maybe_finalize_save_checkpoint.call_count == 2
+    assert wrapped_io.maybe_finalize_save_checkpoint.call_count == 2
     assert trainer.strategy.barrier.call_count == 2
 
     # Verify file deletion
@@ -521,9 +536,11 @@ def test_on_train_end_skips_cleanup_when_flag_is_true(mocker, tmp_path):
         load_strategy=mocker.MagicMock(),
         trainer=trainer,
     )
-    checkpoint_io.maybe_finalize_save_checkpoint = mocker.MagicMock()
     mocker.spy(checkpoint_io, "remove_checkpoint")
-    trainer.strategy.checkpoint_io = checkpoint_io
+
+    wrapped_io = MLFlashpointAsyncFinalizableCheckpointIO(checkpoint_io)
+    mocker.spy(wrapped_io, "maybe_finalize_save_checkpoint")
+    trainer.strategy.checkpoint_io = wrapped_io
 
     pl_module = mocker.MagicMock(spec=pl.LightningModule)
 
@@ -543,12 +560,11 @@ def test_on_train_end_skips_cleanup_when_flag_is_true(mocker, tmp_path):
     callback.on_train_end(trainer, pl_module)
 
     # Then
-    checkpoint_io.maybe_finalize_save_checkpoint.assert_called_once_with(blocking=True)
+    wrapped_io.maybe_finalize_save_checkpoint.assert_called_once_with(blocking=True)
     trainer.strategy.barrier.assert_called_once_with("mlf_cleanup_barrier")
     callback.replication_manager.shutdown.assert_called_once()
 
     checkpoint_io.remove_checkpoint.assert_not_called()
-
     assert base_container_path.exists(), "Base container directory should NOT have been deleted"
     assert dummy_file.exists(), "Dummy file should NOT have been deleted"
 

--- a/tests/adapter/nemo/test_checkpoint_callback.py
+++ b/tests/adapter/nemo/test_checkpoint_callback.py
@@ -442,7 +442,10 @@ def test_on_train_end_skips_cleanup_on_non_zero_rank(mocker, tmp_path):
     callback.replication_manager.shutdown.assert_called_once()
 
     checkpoint_io.remove_checkpoint.assert_not_called()
-    assert base_container_path.exists()
+
+    # Verify file retention
+    assert base_container_path.exists(), "Base container directory should NOT have been deleted"
+    assert dummy_file.exists(), "Dummy file should NOT have been deleted"
 
 
 def test_on_train_end_no_replication_manager_skips_shutdown(mocker):

--- a/tests/adapter/nemo/test_checkpoint_callback.py
+++ b/tests/adapter/nemo/test_checkpoint_callback.py
@@ -399,6 +399,7 @@ def test_on_train_end_cleans_up_on_rank_zero(mocker, tmp_path):
 
     # Verify file deletion
     assert not base_container_path.exists(), "Base container directory should have been deleted"
+    assert not dummy_file.exists(), "Dummy file should have been deleted"
 
 
 def test_on_train_end_skips_cleanup_on_non_zero_rank(mocker, tmp_path):
@@ -515,6 +516,7 @@ def test_on_train_end_is_idempotent(mocker, tmp_path):
 
     # Verify file deletion
     assert not base_container_path.exists(), "Base container directory should have been deleted"
+    assert not dummy_file.exists(), "Dummy file should have been deleted"
 
 
 def test_on_train_end_skips_cleanup_when_flag_is_true(mocker, tmp_path):
@@ -572,31 +574,53 @@ def test_on_train_end_skips_cleanup_when_flag_is_true(mocker, tmp_path):
     assert dummy_file.exists(), "Dummy file should NOT have been deleted"
 
 
-def test_on_train_end_with_sync_checkpoint_io(mocker):
+def test_on_train_end_with_sync_checkpoint_io(mocker, tmp_path):
     """
-    Tests that on_train_end executes successfully during synchronous saving.
+    Tests that on_train_end executes successfully during synchronous saving
+    when CheckpointIO is an instance of MLFlashpointCheckpointIO .
     """
-    mock_trainer = mocker.MagicMock()
-    mock_strategy = mocker.MagicMock()
-    mock_checkpoint_io = mocker.MagicMock()
+    # Given
+    trainer = mocker.MagicMock(spec=pl.Trainer)
+    trainer.local_rank = 0
+    chkpt_obj_manager = CheckpointObjectManager()
 
-    # Remove the async-specific method to simulate a synchronous CheckpointIO instance.
-    del mock_checkpoint_io.maybe_finalize_save_checkpoint
-
-    mock_strategy.checkpoint_io = mock_checkpoint_io
-    mock_trainer.strategy = mock_strategy
-    mock_trainer.local_rank = 0
-
-    callback = MLFlashpointCheckpointCallback(
-        checkpoint_base_container="/tmp/fake_base",
-        every_n_steps=10,
+    checkpoint_io = MLFlashpointCheckpointIO(
+        flashpoint_base_path=str(tmp_path / "ckpt_base"),
+        alt_checkpoint_io=mocker.MagicMock(),
+        chkpt_obj_manager=chkpt_obj_manager,
+        save_strategy=mocker.MagicMock(),
+        load_strategy=mocker.MagicMock(),
+        trainer=trainer,
     )
+    mocker.spy(checkpoint_io, "remove_checkpoint")
 
+    trainer.strategy.checkpoint_io = checkpoint_io
+
+    pl_module = mocker.MagicMock(spec=pl.LightningModule)
+
+    # Create a base container directory and a dummy file inside it
+    base_container_path = tmp_path / "ckpt_base"
+    base_container_path.mkdir()
+    dummy_file = base_container_path / "dummy.txt"
+    dummy_file.write_text("dummy")
+
+    base_container = CheckpointContainerId(str(base_container_path))
+    callback = MLFlashpointCheckpointCallback(checkpoint_base_container=base_container, every_n_steps=10)
+    callback.replication_manager = mocker.MagicMock()
+
+    # When
     # Execute on_train_end; it should gracefully skip finalization without errors.
     try:
-        callback.on_train_end(trainer=mock_trainer, pl_module=mocker.MagicMock())
+        callback.on_train_end(trainer=trainer, pl_module=pl_module)
     except AttributeError as e:
         pytest.fail(f"on_train_end failed to handle synchronous CheckpointIO: {e}")
 
+    # Then
     # Verify that the subsequent cleanup steps (e.g., barrier) are still reached.
-    mock_trainer.strategy.barrier.assert_called_once_with("mlf_cleanup_barrier")
+    trainer.strategy.barrier.assert_called_once_with("mlf_cleanup_barrier")
+    callback.replication_manager.shutdown.assert_called_once()
+    checkpoint_io.remove_checkpoint.assert_called_once_with(base_container.data)
+
+    # Verify file deletion
+    assert not base_container_path.exists(), "Base container directory should have been deleted"
+    assert not dummy_file.exists(), "Dummy file should have been deleted"


### PR DESCRIPTION
When synchronous checkpoint saving is used (`ckpt_async_save=False`), the underlying `checkpoint_io` is the base `MLFlashpointCheckpointIO` class, which does not possess the `maybe_finalize_save_checkpoint` method. This method is specifically provided by the async wrapper `MLFlashpointAsyncFinalizableCheckpointIO`.

Previously, the `on_train_end` callback unconditionally called this method, leading to an `AttributeError` and causing unsuccessfull checkpointing.

Change-Id: I5e9bbf698b8ac5137f7ab3a6a723ac1e7cd3c085
