### PR TITLE
perf(adapter/megatron): do sync save in main thread, not separate process

### DIFF
--- a/src/ml_flashpoint/adapter/megatron/save_strategies.py
+++ b/src/ml_flashpoint/adapter/megatron/save_strategies.py
@@ -261,6 +261,7 @@ class MLFlashpointMegatronAsyncSaveStrategy(AsyncSaveShardedStrategy):
         )
 
     @override
+    @log_execution_time(logger=_LOGGER, name="save", level=logging.INFO)
     def save(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Union[str, Path]):
         """Trivial sync implementation that does not spin up a new process."""
         async_request = self.async_save(sharded_state_dict, checkpoint_dir)

--- a/src/ml_flashpoint/adapter/megatron/save_strategies.py
+++ b/src/ml_flashpoint/adapter/megatron/save_strategies.py
@@ -259,3 +259,27 @@ class MLFlashpointMegatronAsyncSaveStrategy(AsyncSaveShardedStrategy):
             },
             finalize_fns=finalize_fns,
         )
+
+    @override
+    def save(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Union[str, Path]):
+        """Trivial sync implementation that does not spin up a new process."""
+        async_request = self.async_save(sharded_state_dict, checkpoint_dir)
+
+        async_fn_args = list(async_request.async_fn_args)
+        if async_request.preload_fn is not None:
+            preload_result = async_request.preload_fn()
+            if len(async_fn_args) > 1:
+                async_fn_args[1] = preload_result
+
+        # Ensure all async D2H copies are finished before writing
+        if torch.cuda.is_initialized():
+            torch.cuda.synchronize()
+
+        if async_request.async_fn is not None:
+            async_request.async_fn(*async_fn_args, **async_request.async_fn_kwargs)
+
+        for finalize_fn in async_request.finalize_fns:
+            finalize_fn()
+
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()

--- a/tests/adapter/megatron/test_save_strategies.py
+++ b/tests/adapter/megatron/test_save_strategies.py
@@ -721,13 +721,9 @@ class TestMLFlashpointMegatronAsyncSaveStrategy:
             def dummy_finalize_fn():
                 pass
 
-            mock_async_fn = (
-                mocker.MagicMock(spec=dummy_async_fn) if has_async_fn else None
-            )
+            mock_async_fn = mocker.MagicMock(spec=dummy_async_fn) if has_async_fn else None
             mock_preload_fn = (
-                mocker.MagicMock(spec=dummy_preload_fn, return_value="preload_result")
-                if has_preload
-                else None
+                mocker.MagicMock(spec=dummy_preload_fn, return_value="preload_result") if has_preload else None
             )
             mock_finalize_fn1 = mocker.MagicMock(spec=dummy_finalize_fn)
             mock_finalize_fn2 = mocker.MagicMock(spec=dummy_finalize_fn)

--- a/tests/adapter/megatron/test_save_strategies.py
+++ b/tests/adapter/megatron/test_save_strategies.py
@@ -730,7 +730,7 @@ class TestMLFlashpointMegatronAsyncSaveStrategy:
 
             async_fn_args = tuple(f"arg{i}" for i in range(args_len))
 
-            mock_async_request = AsyncRequest(
+            test_async_request = AsyncRequest(
                 async_fn=mock_async_fn,
                 async_fn_args=async_fn_args,
                 async_fn_kwargs={"kwarg1": "val1"},
@@ -738,7 +738,7 @@ class TestMLFlashpointMegatronAsyncSaveStrategy:
                 preload_fn=mock_preload_fn,
             )
 
-            mocker.patch.object(strategy, "async_save", return_value=mock_async_request)
+            mocker.patch.object(strategy, "async_save", return_value=test_async_request)
 
             mocker.patch("torch.distributed.is_initialized", return_value=dist_initialized)
             mock_barrier = mocker.patch("torch.distributed.barrier", spec=torch.distributed.barrier)

--- a/tests/adapter/megatron/test_save_strategies.py
+++ b/tests/adapter/megatron/test_save_strategies.py
@@ -15,6 +15,7 @@
 import pytest
 import torch
 from megatron.core.dist_checkpointing.mapping import ShardedTensor
+from megatron.core.dist_checkpointing.strategies.async_utils import AsyncRequest
 from torch.distributed.checkpoint import metadata as torchdistmeta
 from torch.distributed.checkpoint.planner import SavePlan, WriteItem, WriteItemType
 
@@ -691,3 +692,42 @@ class TestMLFlashpointMegatronAsyncSaveStrategy:
             # Verify modifications to bound_metadata don't affect cache
             bound_metadata.storage_data = "NEW_DIRTY"
             assert strategy._cached_global_metadata.storage_data is None
+
+        def test_save_success(self, mocker, async_save_setup):
+            """Tests that save method executes async_fn and finalize_fns synchronously with preload and cuda sync."""
+            # Given
+            strategy, checkpoint_id, sharded_state_dict, _ = async_save_setup
+
+            mock_async_fn = mocker.MagicMock()
+            mock_preload_fn = mocker.MagicMock(return_value="preload_result")
+            mock_finalize_fn1 = mocker.MagicMock()
+            mock_finalize_fn2 = mocker.MagicMock()
+
+            mock_async_request = AsyncRequest(
+                async_fn=mock_async_fn,
+                async_fn_args=("arg0", "arg1"),
+                async_fn_kwargs={"kwarg1": "val1"},
+                finalize_fns=[mock_finalize_fn1, mock_finalize_fn2],
+                preload_fn=mock_preload_fn,
+            )
+
+            mocker.patch.object(strategy, "async_save", return_value=mock_async_request)
+
+            mock_barrier = mocker.patch("torch.distributed.barrier")
+            mocker.patch("torch.cuda.is_initialized", return_value=True)
+            mock_cuda_sync = mocker.patch("torch.cuda.synchronize")
+
+            # When
+            strategy.save(sharded_state_dict, checkpoint_id.data)
+
+            # Then
+            mock_preload_fn.assert_called_once()
+            mock_cuda_sync.assert_called_once()
+
+            # Check that async_fn was called with updated args
+            # arg1 should be replaced by preload_result
+            mock_async_fn.assert_called_once_with("arg0", "preload_result", kwarg1="val1")
+
+            mock_barrier.assert_called_once()
+            mock_finalize_fn1.assert_called_once()
+            mock_finalize_fn2.assert_called_once()

--- a/tests/adapter/megatron/test_save_strategies.py
+++ b/tests/adapter/megatron/test_save_strategies.py
@@ -693,19 +693,50 @@ class TestMLFlashpointMegatronAsyncSaveStrategy:
             bound_metadata.storage_data = "NEW_DIRTY"
             assert strategy._cached_global_metadata.storage_data is None
 
-        def test_save_success(self, mocker, async_save_setup):
+        @pytest.mark.parametrize("has_preload", [True, False])
+        @pytest.mark.parametrize("cuda_initialized", [True, False])
+        @pytest.mark.parametrize("dist_initialized", [True, False])
+        @pytest.mark.parametrize("has_async_fn", [True, False])
+        @pytest.mark.parametrize("args_len", [0, 1, 2])
+        def test_sync_save_success(
+            self,
+            mocker,
+            async_save_setup,
+            has_preload,
+            cuda_initialized,
+            dist_initialized,
+            has_async_fn,
+            args_len,
+        ):
             """Tests that save method executes async_fn and finalize_fns synchronously with preload and cuda sync."""
             # Given
             strategy, checkpoint_id, sharded_state_dict, _ = async_save_setup
 
-            mock_async_fn = mocker.MagicMock()
-            mock_preload_fn = mocker.MagicMock(return_value="preload_result")
-            mock_finalize_fn1 = mocker.MagicMock()
-            mock_finalize_fn2 = mocker.MagicMock()
+            def dummy_async_fn(*args, **kwargs):
+                pass
+
+            def dummy_preload_fn():
+                return "preload_result"
+
+            def dummy_finalize_fn():
+                pass
+
+            mock_async_fn = (
+                mocker.MagicMock(spec=dummy_async_fn) if has_async_fn else None
+            )
+            mock_preload_fn = (
+                mocker.MagicMock(spec=dummy_preload_fn, return_value="preload_result")
+                if has_preload
+                else None
+            )
+            mock_finalize_fn1 = mocker.MagicMock(spec=dummy_finalize_fn)
+            mock_finalize_fn2 = mocker.MagicMock(spec=dummy_finalize_fn)
+
+            async_fn_args = tuple(f"arg{i}" for i in range(args_len))
 
             mock_async_request = AsyncRequest(
                 async_fn=mock_async_fn,
-                async_fn_args=("arg0", "arg1"),
+                async_fn_args=async_fn_args,
                 async_fn_kwargs={"kwarg1": "val1"},
                 finalize_fns=[mock_finalize_fn1, mock_finalize_fn2],
                 preload_fn=mock_preload_fn,
@@ -713,21 +744,34 @@ class TestMLFlashpointMegatronAsyncSaveStrategy:
 
             mocker.patch.object(strategy, "async_save", return_value=mock_async_request)
 
-            mock_barrier = mocker.patch("torch.distributed.barrier")
-            mocker.patch("torch.cuda.is_initialized", return_value=True)
-            mock_cuda_sync = mocker.patch("torch.cuda.synchronize")
+            mocker.patch("torch.distributed.is_initialized", return_value=dist_initialized)
+            mock_barrier = mocker.patch("torch.distributed.barrier", spec=torch.distributed.barrier)
+
+            mocker.patch("torch.cuda.is_initialized", return_value=cuda_initialized)
+            mock_cuda_sync = mocker.patch("torch.cuda.synchronize", spec=torch.cuda.synchronize)
 
             # When
             strategy.save(sharded_state_dict, checkpoint_id.data)
 
             # Then
-            mock_preload_fn.assert_called_once()
-            mock_cuda_sync.assert_called_once()
+            if has_preload:
+                mock_preload_fn.assert_called_once()
 
-            # Check that async_fn was called with updated args
-            # arg1 should be replaced by preload_result
-            mock_async_fn.assert_called_once_with("arg0", "preload_result", kwarg1="val1")
+            if has_async_fn:
+                expected_args = list(async_fn_args)
+                if has_preload and args_len > 1:
+                    expected_args[1] = "preload_result"
+                mock_async_fn.assert_called_once_with(*expected_args, kwarg1="val1")
 
-            mock_barrier.assert_called_once()
+            if cuda_initialized:
+                mock_cuda_sync.assert_called_once()
+            else:
+                mock_cuda_sync.assert_not_called()
+
+            if dist_initialized:
+                mock_barrier.assert_called_once()
+            else:
+                mock_barrier.assert_not_called()
+
             mock_finalize_fn1.assert_called_once()
             mock_finalize_fn2.assert_called_once()


### PR DESCRIPTION
The default sync save impl in Megatron's `AsyncSaveShardedStrategy`, which is the `save()` method, simply calls `async_save(...)`, schedules it (which kicks off a worker process to do the work), then blocks and waits for that process to finish, and cleans it up if it is not a persistent process. 

This adds unnecessary overhead when doing synchronous saving, as all that work can just be done in the main thread, which is simpler. This change does just that.